### PR TITLE
Use MinVer and Microsoft.SourceLink.GitHub to generate assembly metadata at build time

### DIFF
--- a/NuGetTools.sln
+++ b/NuGetTools.sln
@@ -4,6 +4,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 15.0.26412.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{C65B2136-1245-4F2D-950F-55187D51FEC0}"
+	ProjectSection(SolutionItems) = preProject
+		src\Directory.Build.props = src\Directory.Build.props
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A4ECEBC3-81BD-4BE4-80E7-D4011B729DA2}"
 	ProjectSection(SolutionItems) = preProject

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,17 @@
+<Project>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
+    <PackageReference Include="MinVer" Version="4.3.0" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyMetadata Include="BuildTimestamp" Condition="$(Configuration) == 'Debug'">
+      <Value>$([System.DateTime]::Today.ToString("O"))</Value>
+    </AssemblyMetadata>
+    <AssemblyMetadata Include="BuildTimestamp" Condition="$(Configuration) != 'Debug'">
+      <Value>$([System.DateTime]::Now.ToString("O"))</Value>
+    </AssemblyMetadata>
+  </ItemGroup>
+
+</Project>

--- a/src/Knapcode.NuGetTools.Logic.Direct/Knapcode.NuGetTools.Logic.Direct.csproj
+++ b/src/Knapcode.NuGetTools.Logic.Direct/Knapcode.NuGetTools.Logic.Direct.csproj
@@ -4,9 +4,6 @@
     <TargetFramework>net472</TargetFramework>
     <AssemblyName>Knapcode.NuGetTools.Logic.Direct</AssemblyName>
     <PackageId>Knapcode.NuGetTools.Logic.Direct</PackageId>
-    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Knapcode.NuGetTools.Logic/Knapcode.NuGetTools.Logic.csproj
+++ b/src/Knapcode.NuGetTools.Logic/Knapcode.NuGetTools.Logic.csproj
@@ -4,9 +4,6 @@
     <TargetFramework>net472</TargetFramework>
     <AssemblyName>Knapcode.NuGetTools.Logic</AssemblyName>
     <PackageId>Knapcode.NuGetTools.Logic</PackageId>
-    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">

--- a/src/Knapcode.NuGetTools.PackageDownloader/Knapcode.NuGetTools.PackageDownloader.csproj
+++ b/src/Knapcode.NuGetTools.PackageDownloader/Knapcode.NuGetTools.PackageDownloader.csproj
@@ -5,9 +5,6 @@
     <AssemblyName>Knapcode.NuGetTools.PackageDownloader</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Knapcode.NuGetTools.PackageDownloader</PackageId>
-    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Knapcode.NuGetTools.Sandbox/Knapcode.NuGetTools.Sandbox.csproj
+++ b/src/Knapcode.NuGetTools.Sandbox/Knapcode.NuGetTools.Sandbox.csproj
@@ -5,9 +5,6 @@
     <AssemblyName>Knapcode.NuGetTools.Sandbox</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Knapcode.NuGetTools.Sandbox</PackageId>
-    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Knapcode.NuGetTools.Website/Configuration.cs
+++ b/src/Knapcode.NuGetTools.Website/Configuration.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using NuGet.Versioning;
 
 namespace Knapcode.NuGetTools.Website
 {
@@ -23,15 +24,17 @@ namespace Knapcode.NuGetTools.Website
                 .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
                 .InformationalVersion;
 
-            AssemblyCommitHash = assembly
-                .GetCustomAttributes<AssemblyMetadataAttribute>()
-                .FirstOrDefault(x => x.Key == "CommitHash")?
-                .Value;
+            if (SemanticVersion.TryParse(AssemblyInformationalVersion, out var version))
+            {
+                AssemblyCommitHash = version.Metadata;
+                var shortCommitHash = version.Metadata.Length > 8 ? version.Metadata.Substring(0, 8) : version.Metadata;
+                AssemblyInformationalVersion = new SemanticVersion(version.Major, version.Minor, version.Patch, version.ReleaseLabels, shortCommitHash).ToFullString();
+            }
 
             AssemblyBuildTimestamp = DateTimeOffset.Parse(assembly
                 .GetCustomAttributes<AssemblyMetadataAttribute>()
                 .FirstOrDefault(x => x.Key == "BuildTimestamp")?
-                .Value, CultureInfo.InvariantCulture);
+                .Value ?? "2001-01-01", CultureInfo.InvariantCulture);
         }
 
         public static string AssemblyVersion { get; private set; }

--- a/src/Knapcode.NuGetTools.Website/Knapcode.NuGetTools.Website.csproj
+++ b/src/Knapcode.NuGetTools.Website/Knapcode.NuGetTools.Website.csproj
@@ -6,9 +6,6 @@
     <AssemblyName>Knapcode.NuGetTools.Website</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Knapcode.NuGetTools.Website</PackageId>
-    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This should remove the need for `Knapcode.NuGetTools.Build` altogether.

Also, running the `Knapcode.NuGetTools.Website` project after a fresh checkout just works, without any exception. Previously, it would throw `ArgumentNullException` because the `BuildTimestamp` assembly metadata would not be found.

> ArgumentNullException: String reference not set to an instance of a String. Parameter name: s
>   System.DateTimeParse.Parse(string s, DateTimeFormatInfo dtfi, DateTimeStyles styles, out TimeSpan offset)
>   System.DateTimeOffset.Parse(string input, IFormatProvider formatProvider, DateTimeStyles styles)
>   Knapcode.NuGetTools.Website.Configuration..cctor() in Configuration.cs