### PR TITLE
Make webapp debugable directly from solution

### DIFF
--- a/src/Knapcode.NuGetTools.Website/Knapcode.NuGetTools.Website.csproj
+++ b/src/Knapcode.NuGetTools.Website/Knapcode.NuGetTools.Website.csproj
@@ -48,6 +48,13 @@
     </Content>
   </ItemGroup>
 
+  <ItemGroup>
+	  <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+		  <_Parameter1>BuildTimestamp</_Parameter1>
+		  <_Parameter2>$([System.DateTime]::UtcNow.ToString('yyyy-MM-dd'))</_Parameter2>
+	  </AssemblyAttribute>
+  </ItemGroup>
+
   <Target Name="PrepublishScript" BeforeTargets="PrepareForPublish">
     <Exec Command="bower install" />
   </Target>


### PR DESCRIPTION
Fixes: https://github.com/joelverhagen/NuGetTools/issues/23

However, I don't know if this is going to break your CI build, or app that gets deployed, so please review this carefully.

If you use SourceLink, I think it will already create an assembly attribute with the commit hash (maybe even a static class with the commit hash as a const string), so you can probably get rid of the `Build` app.