### PR TITLE
Make the deploy action friendly to forks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,6 +71,11 @@ jobs:
           Write-Output "versions-changed=$(($notMatching.Length -ne 0).ToString().ToLowerInvariant())" >> $env:GITHUB_OUTPUT
 
   deploy-to-dev:
+    env:
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+    if: env.AZURE_TENANT_ID != '' && env.AZURE_CLIENT_ID != '' && env.AZURE_SUBSCRIPTION_ID != ''
     permissions:
       id-token: write
       contents: read
@@ -93,9 +98,9 @@ jobs:
       - name: Log in to Azure
         uses: azure/login@v2
         with:
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
 
       - name: Deploy
         id: deploy
@@ -105,6 +110,14 @@ jobs:
           package: ./website.zip
 
   deploy-to-prod:
+    env:
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      RESOURCE_GROUP: Knapcode.NuGetTools
+      WEBAPP_NAME: NuGetTools
+      SLOT_NAME: staging
+    if: env.AZURE_TENANT_ID != '' && env.AZURE_CLIENT_ID != '' && env.AZURE_SUBSCRIPTION_ID != ''
     permissions:
       id-token: write
       contents: read
@@ -113,11 +126,6 @@ jobs:
     environment:
       name: PROD
       url: ${{ steps.set-environment-url.outputs.url }}
-
-    env:
-      RESOURCE_GROUP: Knapcode.NuGetTools
-      WEBAPP_NAME: NuGetTools
-      SLOT_NAME: staging
 
     steps:
       - name: Check out
@@ -132,9 +140,9 @@ jobs:
       - name: Log in to Azure
         uses: azure/login@v2
         with:
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
 
       - name: Deploy
         id: deploy

--- a/NuGetTools.sln
+++ b/NuGetTools.sln
@@ -35,6 +35,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Knapcode.NuGetTools.Logic.N
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Knapcode.NuGetTools.Logic.NuGet2x", "src\Knapcode.NuGetTools.Logic.NuGet2x\Knapcode.NuGetTools.Logic.NuGet2x.csproj", "{F7C925D0-D3E8-470C-B095-AD4EA9103ED4}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{41599FB4-DDD2-47E3-98FF-659A4854DD07}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\ci.yml = .github\workflows\ci.yml
+		.github\workflows\deploy.yml = .github\workflows\deploy.yml
+		.github\workflows\keep-alive.yml = .github\workflows\keep-alive.yml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -120,6 +127,7 @@ Global
 		{2EE6D448-3E19-432C-A25B-E21474D8D8E3} = {C65B2136-1245-4F2D-950F-55187D51FEC0}
 		{EE80559E-3E56-472C-A3DA-49213721F938} = {C65B2136-1245-4F2D-950F-55187D51FEC0}
 		{F7C925D0-D3E8-470C-B095-AD4EA9103ED4} = {C65B2136-1245-4F2D-950F-55187D51FEC0}
+		{41599FB4-DDD2-47E3-98FF-659A4854DD07} = {A4ECEBC3-81BD-4BE4-80E7-D4011B729DA2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {22DC91EB-7A5F-46AA-992C-9C28049612AD}


### PR DESCRIPTION
Don't try to deploy if the AZURE_* secrets are not defined.

Currently this error occurs every day in my fork:
> Login failed with Error: Using auth-type: SERVICE_PRINCIPAL. Not all values are present. Ensure 'client-id' and 'tenant-id' are supplied..

Note that the secrets are copied into environment variables because [secrets cannot be directly referenced in `if:` conditionals](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-using-secrets).