### PR TITLE
Only run the deploy jobs for the joelverhagen/NuGetTools repository

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,7 @@ env:
 
 jobs:
   build:
+    if: github.repository == 'joelverhagen/NuGetTools'
     runs-on: windows-latest
     defaults:
       run:
@@ -71,6 +72,7 @@ jobs:
           Write-Output "versions-changed=$(($notMatching.Length -ne 0).ToString().ToLowerInvariant())" >> $env:GITHUB_OUTPUT
 
   deploy-to-dev:
+    if: github.repository == 'joelverhagen/NuGetTools'
     permissions:
       id-token: write
       contents: read
@@ -105,6 +107,7 @@ jobs:
           package: ./website.zip
 
   deploy-to-prod:
+    if: github.repository == 'joelverhagen/NuGetTools'
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,11 +71,6 @@ jobs:
           Write-Output "versions-changed=$(($notMatching.Length -ne 0).ToString().ToLowerInvariant())" >> $env:GITHUB_OUTPUT
 
   deploy-to-dev:
-    env:
-      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-    if: env.AZURE_TENANT_ID != '' && env.AZURE_CLIENT_ID != '' && env.AZURE_SUBSCRIPTION_ID != ''
     permissions:
       id-token: write
       contents: read
@@ -98,9 +93,9 @@ jobs:
       - name: Log in to Azure
         uses: azure/login@v2
         with:
-          tenant-id: ${{ env.AZURE_TENANT_ID }}
-          client-id: ${{ env.AZURE_CLIENT_ID }}
-          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Deploy
         id: deploy
@@ -110,14 +105,6 @@ jobs:
           package: ./website.zip
 
   deploy-to-prod:
-    env:
-      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      RESOURCE_GROUP: Knapcode.NuGetTools
-      WEBAPP_NAME: NuGetTools
-      SLOT_NAME: staging
-    if: env.AZURE_TENANT_ID != '' && env.AZURE_CLIENT_ID != '' && env.AZURE_SUBSCRIPTION_ID != ''
     permissions:
       id-token: write
       contents: read
@@ -126,6 +113,11 @@ jobs:
     environment:
       name: PROD
       url: ${{ steps.set-environment-url.outputs.url }}
+
+    env:
+      RESOURCE_GROUP: Knapcode.NuGetTools
+      WEBAPP_NAME: NuGetTools
+      SLOT_NAME: staging
 
     steps:
       - name: Check out
@@ -140,9 +132,9 @@ jobs:
       - name: Log in to Azure
         uses: azure/login@v2
         with:
-          tenant-id: ${{ env.AZURE_TENANT_ID }}
-          client-id: ${{ env.AZURE_CLIENT_ID }}
-          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Deploy
         id: deploy


### PR DESCRIPTION
Sorry about #71, it did not work as expected. By the way, this issue already [suprised many many people](https://github.com/actions/runner/issues/1189). 🙄

This new approach should work since it's exactly what's documented on [Example: Only run job for specific repository](https://docs.github.com/en/actions/how-tos/writing-workflows/choosing-when-your-workflow-runs/using-conditions-to-control-job-execution#example-only-run-job-for-specific-repository).