### PR TITLE
Only run the keep-alive job for the joelverhagen/NuGetTools repository

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   keep-alive:
+    if: github.repository == 'joelverhagen/NuGetTools'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Just like #72 but for the "Keep alive" job.

As long as latest-versions.json was not changed it was fine but once it changed the following error started to occur daily on `git push`:
> remote: Permission to 0xced/NuGetTools.git denied to github-actions[bot].
> fatal: unable to access 'https://github.com/0xced/NuGetTools/': The requested URL returned error: 403